### PR TITLE
Use docker for sanity tests

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -5,37 +5,63 @@ on:
     - cron: "0 3 * * *"
 
 jobs:
+
+###
+# Sanity tests (REQUIRED)
+#
+# https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html
+
   sanity:
-    runs-on: ubuntu-20.04
-    defaults:
-      run:
-        working-directory: ansible_collections/community/elastic
+    name: Sanity (Ⓐ${{ matrix.ansible }})
     strategy:
       matrix:
-        ansible_version:
+        ansible:
+          # It's important that Sanity is tested against all stable-X.Y branches
+          # Testing against `devel` may fail as new tests are added.
+          # An alternative to `devel` is the `milestone` branch with
+          # gets synchronized with `devel` every few weeks and therefore
+          # tends to be a more stable target. Be aware that it is not updated
+          # around creation of a new stable branch, this might cause a problem
+          # that two different versions of ansible-test use the same sanity test
+          # ignore.txt file.
+          # Add new versions announced in
+          # https://github.com/ansible-collections/news-for-maintainers in a timely manner,
+          # consider dropping testing against EOL versions and versions you don't support.
           - stable-2.13
-          - devel
+          - stable-2.14
+          - stable-2.15
+        # - devel
+          - milestone
+    # Ansible-test on various stable branches does not yet work well with cgroups v2.
+    # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
+    # image for these stable branches. The list of branches where this is necessary will
+    # shrink over time, check out https://github.com/ansible-collections/news-for-maintainers/issues/28
+    # for the latest list.
+    runs-on: >-
+      ${{ contains(fromJson(
+          '["stable-2.9", "stable-2.10", "stable-2.11"]'
+      ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
     steps:
 
-      - name: Check out code
-        uses: actions/checkout@v3
+      # Run sanity tests inside a Docker container.
+      # The docker container has all the pinned dependencies that are
+      # required and all Python versions Ansible supports.
+      - name: Perform sanity testing
+        # See the documentation for the following GitHub action on
+        # https://github.com/ansible-community/ansible-test-gh-action/blob/main/README.md
+        uses: ansible-community/ansible-test-gh-action@release/v1
         with:
-          path: ansible_collections/community/elastic
-
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-
-      - name: Install ansible-base (${{ matrix.ansible_version }})
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 3
-          max_attempts: 3
-          command: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible_version }}.tar.gz --disable-pip-version-check
-
-      - name: Run sanity tests
-        run: ansible-test sanity --docker -v --color
+          ansible-core-version: ${{ matrix.ansible }}
+          testing-type: sanity
+          # OPTIONAL If your sanity tests require code
+          # from other collections, install them like this
+          # test-deps: >-
+          #   ansible.netcommon
+          #   ansible.utils
+          # OPTIONAL If set to true, will test only against changed files,
+          # which should improve CI performance. See limitations on
+          # https://github.com/ansible-community/ansible-test-gh-action#pull-request-change-detection
+          pull-request-change-detection: true
 
   #units:
   #  runs-on: ubuntu-20.04
@@ -114,8 +140,8 @@ jobs:
             python_version: "3.8"
           - ansible_version: stable-2.13
             python_version: "3.9"
-          - ansible_version: devel
-            python_version: "3.10"
+          - ansible_version: milestone
+            python_version: "3.11"
         elasticsearch_version_combinations:
           - elasticsearch_version: 7.10.1
             kibana_version: 7.10.1


### PR DESCRIPTION
* collection_template uses the same strategy https://github.com/ansible-collections/collection_template/blob/main/.github/workflows/ansible-test.yml

* Use 'milestone' ansible version for more stability

##### SUMMARY
This change is a requirement to get Elasticsearch 8.x supported.

Now sanity tests are executed with Docker with dependancies already prepared (eg Pyhon).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Change to improve CI

##### ADDITIONAL INFORMATION
Nothing more