### PR TITLE
Support Elasticsearch 8 (#58)

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -145,6 +145,10 @@ jobs:
         elasticsearch_version_combinations:
           - elasticsearch_version: 7.10.1
             kibana_version: 7.10.1
+            elasticsearch_python_lib: elasticsearch==7.*
+          - elasticsearch_version: 8.8.2
+            kibana_version: 8.8.2
+            elasticsearch_python_lib: elasticsearch==8.*
 
     steps:
 
@@ -163,7 +167,7 @@ jobs:
         with:
           timeout_minutes: 3
           max_attempts: 3
-          command: pip install docker elasticsearch==7.* requests coverage
+          command: pip install docker ${{ matrix.elasticsearch_version_combinations.elasticsearch_python_lib }} requests coverage
 
       - name: Install ansible-base (${{ matrix.ansible_version_combinations.ansible_version }})
         uses: nick-invision/retry@v2

--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ Not yet available.
 
 # Installing the latest development version
 
-At the moment please ensure you are using version 7 of the elasticsearch driver. [8+ is not currently supported](https://github.com/ansible-collections/community.elastic/issues/58).
+Both Elasticsearch server version 7 and 8 are supported. But the version
+of elasticesearch Python library must be aligned with Elasticsearch server.
 
 ```bash
-pip install elasticsearch==7.*
+pip install elasticsearch==7.*  # To connect to Elasticsearch 7.x
+pip install elasticsearch==8.*  # To connect to Elasticsearch 8.x
 ```
 
 ```bash

--- a/plugins/module_utils/elastic_common.py
+++ b/plugins/module_utils/elastic_common.py
@@ -8,11 +8,14 @@ elastic_found = False
 E_IMP_ERR = None
 NotFoundError = None
 helpers = None
+__version__ = None
 
 try:
     from elasticsearch import Elasticsearch
     from elasticsearch.exceptions import NotFoundError  # pylint: disable=unused-import
     from elasticsearch import helpers  # pylint: disable=unused-import
+    from elasticsearch import __version__  # pylint: disable=unused-import
+
     elastic_found = True
 except ImportError:
     E_IMP_ERR = traceback.format_exc()
@@ -55,7 +58,6 @@ class ElasticHelpers():
                 auth["http_auth"] = (module.params['login_user'],
                                      module.params['login_password'])
 
-                auth["http_scheme"] = module.params['auth_scheme']
                 if module.params['cafile'] is not None:
                     from ssl import create_default_context
                     context = create_default_context(module.params['cafile'])
@@ -92,5 +94,5 @@ class ElasticHelpers():
             module.fail_json(msg='Cannot perform {0} action on an index that does not exist'.format(method))
         else:
             class_method = getattr(client.indices, method)
-            response = class_method(name)
+            response = class_method(index=name)
             module.exit_json(changed=True, msg="The '{0}' action was performed on the index '{1}'.".format(method, name), **response)

--- a/plugins/modules/elastic_bulk.py
+++ b/plugins/modules/elastic_bulk.py
@@ -116,7 +116,6 @@ def process_document_for_bulk(module, index, action, document):
     bulk_doc = {
         '_op_type': action,
         '_index': index,
-        '_type': '_doc'
     }
     if _id is not None:
         bulk_doc['_id'] = _id
@@ -134,7 +133,7 @@ def get_data_from_file(file_name):
     return data
 
 
-def bulk_json_data(json_file, _index, doc_type):
+def bulk_json_data(json_file, _index):
     '''
     generator to push bulk data from a JSON
     file into an Elasticsearch index
@@ -148,7 +147,6 @@ def bulk_json_data(json_file, _index, doc_type):
         if '{"index"' not in doc:
             yield {
                 "_index": _index,
-                "_type": doc_type,
                 "_id": uuid.uuid4(),
                 "_source": doc
             }
@@ -235,7 +233,7 @@ def main():
                     else:
                         module.fail_json(msg="delete key should be a list")
         elif src is not None:
-            bulk_actions = bulk_json_data(src, index, "document")
+            bulk_actions = bulk_json_data(src, index)
         else:
             module.fail_json(msg="Must supply one of actions or src when executing this module.")
 

--- a/plugins/modules/elastic_cluster_health.py
+++ b/plugins/modules/elastic_cluster_health.py
@@ -35,7 +35,7 @@ options:
     type: str
     choices:
       - cluster
-      - indicies
+      - indices
       - shards
     default: cluster
   local:
@@ -175,7 +175,7 @@ def main():
 
     argument_spec = elastic_common_argument_spec()
     argument_spec.update(
-        level=dict(type='str', choices=['cluster', 'indicies', 'shards'], default='cluster'),
+        level=dict(type='str', choices=['cluster', 'indices', 'shards'], default='cluster'),
         local=dict(type='bool', default=False),
         status=dict(type='str', choices=['green', 'yellow', 'red'], default='green'),
         wait_for=dict(type='str', choices=wait_for_choices, default=None),

--- a/plugins/modules/elastic_cluster_settings.py
+++ b/plugins/modules/elastic_cluster_settings.py
@@ -115,6 +115,8 @@ def main():
         client = elastic.connect()
 
         current_settings = cluster_get_settings(client)
+        if hasattr(current_settings, 'body'):  # Required for Elasticsearch 8.x
+            current_settings = current_settings.body
 
         if persistent:
             del current_settings['transient']

--- a/plugins/modules/elastic_index_info.py
+++ b/plugins/modules/elastic_index_info.py
@@ -87,8 +87,8 @@ def main():
         elastic = ElasticHelpers(module)
         client = elastic.connect()
 
-        if client.indices.exists(name):
-            response = dict(client.indices.get(name))
+        if client.indices.exists(index=name):
+            response = dict(client.indices.get(index=name))
             module.exit_json(changed=False, msg="Info about index {0}.".format(name), **response)
         else:
             module.exit_json(changed=False, msg="The index {0} does not exist.".format(name))

--- a/plugins/modules/elastic_index_lifecycle.py
+++ b/plugins/modules/elastic_index_lifecycle.py
@@ -85,7 +85,8 @@ from ansible_collections.community.elastic.plugins.module_utils.elastic_common i
     E_IMP_ERR,
     elastic_common_argument_spec,
     ElasticHelpers,
-    NotFoundError
+    NotFoundError,
+    __version__
 )
 import json
 
@@ -95,7 +96,8 @@ def get_policy(client, name):
     Gets the policy document specified by name
     '''
     try:
-        policy_doc = client.ilm.get_lifecycle(policy=name)[name]['policy']
+        name_arg = {('policy', 'name')[__version__ >= (8, 0, 0)]: name}
+        policy_doc = client.ilm.get_lifecycle(**name_arg)[name]['policy']
     except NotFoundError:
         policy_doc = None
     return policy_doc
@@ -167,7 +169,8 @@ def main():
                     if module.check_mode:
                         response = {"acknowledged": True}
                     else:
-                        response = dict(client.ilm.put_lifecycle(policy=name, body=request_body))
+                        name_arg = {('policy', 'name')[__version__ >= (8, 0, 0)]: name, 'body': request_body}
+                        response = dict(client.ilm.put_lifecycle(**name_arg))
                     module.exit_json(changed=True, msg="The ILM Policy '{0}' was updated.".format(name), **response)
                 else:
                     module.exit_json(changed=False, msg="The ILM Policy '{0}' is configured as specified.".format(name))
@@ -175,14 +178,16 @@ def main():
                 if module.check_mode:
                     response = {"acknowledged": True}
                 else:
-                    response = dict(client.ilm.put_lifecycle(policy=name, body=request_body))
+                    name_arg = {('policy', 'name')[__version__ >= (8, 0, 0)]: name, 'body': request_body}
+                    response = dict(client.ilm.put_lifecycle(**name_arg))
                 module.exit_json(changed=True, msg="The ILM Policy '{0}' was created.".format(name), **response)
         elif state == 'absent':
             if current_policy is not None:
                 if module.check_mode:
                     response = {"acknowledged": True}
                 else:
-                    response = dict(client.ilm.delete_lifecycle(policy=name))
+                    name_arg = {('policy', 'name')[__version__ >= (8, 0, 0)]: name}
+                    response = dict(client.ilm.delete_lifecycle(**name_arg))
                 module.exit_json(changed=True, msg="The ILM Policy '{0}' was deleted.".format(name), **response)
             else:
                 module.exit_json(changed=False, msg="The ILM Policy '{0}' does not exist.".format(name))

--- a/plugins/modules/elastic_reindex.py
+++ b/plugins/modules/elastic_reindex.py
@@ -97,7 +97,8 @@ from ansible_collections.community.elastic.plugins.module_utils.elastic_common i
     elastic_found,
     E_IMP_ERR,
     elastic_common_argument_spec,
-    ElasticHelpers
+    ElasticHelpers,
+    __version__
 )
 
 
@@ -136,7 +137,12 @@ def main():
         elastic = ElasticHelpers(module)
         client = elastic.connect()
 
-        result = dict(client.reindex({"source": {"index": source}, "dest": {"index": dest}}, wait_for_completion=wait_for_completion))
+        reindex_arg = {"source": {"index": source}, "dest": {"index": dest}}
+        if __version__ >= (8, 0, 0):
+            reindex_arg['wait_for_completion'] = wait_for_completion
+            result = dict(client.reindex(**reindex_arg))
+        else:
+            result = dict(client.reindex(reindex_arg, wait_for_completion=wait_for_completion))
         if isinstance(result, dict) and 'task' in list(result.keys()):
             msg = "The copy task from {0} to {1} has been started.".format(source, dest)
             module.exit_json(changed=True,

--- a/plugins/modules/elastic_rollup.py
+++ b/plugins/modules/elastic_rollup.py
@@ -298,7 +298,7 @@ def main():
                     module.exit_json(changed=True, msg="The rollup job {0} was removed.".format(name))
                 elif state == "started":
                     if job_status["job_state"] == "stopped":
-                        client.rollup.start_job(name)
+                        client.rollup.start_job(id=name)
                         module.exit_json(changed=True, msg="The rollup job {0} was started.".format(name))
                     elif job_status["job_state"] == "started":
                         module.exit_json(changed=False, msg="The rollup job {0} is already in a started state".format(name))
@@ -306,7 +306,7 @@ def main():
                         module.fail_jsob(msg="Job {0} was in a unexpected state: {1}.".format(name, state))
                 elif state == "stopped":
                     if job_status["job_state"] == "started":
-                        client.rollup.stop_job(name)
+                        client.rollup.stop_job(id=name)
                         module.exit_json(changed=True, msg="The rollup job {0} was stopped.".format(name))
                     elif job_status["job_state"] == "stopped":
                         module.exit_json(changed=False, msg="The rollup job {0} is already in a stopped state".format(name))

--- a/tests/integration/targets/elastic_cluster_health/tasks/1-test-no-auth.yml
+++ b/tests/integration/targets/elastic_cluster_health/tasks/1-test-no-auth.yml
@@ -27,9 +27,9 @@
 
   - assert:
       that:
-        - "elastic.active_primary_shards == 0"
-        - "elastic.active_shards == 0"
-        - "elastic.active_shards_percent_as_number == 100.0"
+        - "elastic.active_primary_shards >= 0"
+        - "elastic.active_shards >= 0"
+        - "elastic.active_shards_percent_as_number >= 0.0"
         - "elastic.changed == False"
         - "elastic.cluster_name == 'docker-cluster'"
         - "elastic.delayed_unassigned_shards == 0"
@@ -48,7 +48,7 @@
   - name: Test with indicies level 1
     community.elastic.elastic_cluster_health:
       <<: *elastic_index_parameters
-      level: indicies
+      level: indices
     register: elastic
 
   - assert:
@@ -80,7 +80,7 @@
   - name: Test with indicies level 2
     community.elastic.elastic_cluster_health:
       <<: *elastic_index_parameters
-      level: indicies
+      level: indices
     ignore_errors: yes
     register: elastic
 
@@ -117,7 +117,7 @@
   - name: Test with indicies level 3
     community.elastic.elastic_cluster_health:
       <<: *elastic_index_parameters
-      level: indicies
+      level: indices
     register: elastic
 
   - name: Test with shards level 3

--- a/tests/integration/targets/elastic_cluster_health/tasks/2-test-3-node-with-kibana-no-auth.yml
+++ b/tests/integration/targets/elastic_cluster_health/tasks/2-test-3-node-with-kibana-no-auth.yml
@@ -24,6 +24,8 @@
     community.elastic.elastic_cluster_health:
       status: green
       <<: *elastic_index_parameters
+      poll: 20
+      interval: 3
     ignore_errors: yes
     register: elastic
 
@@ -32,7 +34,7 @@
         - "elastic.msg == 'Elasticsearch health is good.'"
         - "elastic.changed == False"
         - "elastic.status == 'green'"
-        - "elastic.iterations <= 3"
+        - "elastic.iterations <= 20"
 
 
   - name: Basic module test - success expect green
@@ -115,8 +117,8 @@
       - { "wait_for": 'status', "to_be": "green" }
       - { "wait_for": 'number_of_nodes', "to_be": 3 }
       - { "wait_for": 'number_of_data_nodes', "to_be": 3 }
-      - { "wait_for": 'active_primary_shards', "to_be": 6 }
-      - { "wait_for": 'active_shards', "to_be": 12 }
+      - { "wait_for": 'active_primary_shards', "to_be": "{{active_primary_shards}}" }
+      - { "wait_for": 'active_shards', "to_be": "{{active_shards}}" }
       - { "wait_for": 'relocating_shards', "to_be": 0 }
       - { "wait_for": 'initializing_shards', "to_be": 0 }
       - { "wait_for": 'unassigned_shards', "to_be": 0 }
@@ -125,6 +127,11 @@
       - { "wait_for": 'number_of_in_flight_fetch', "to_be": 0 }
       - { "wait_for": 'task_max_waiting_in_queue_millis', "to_be": 0 }
       - { "wait_for": 'active_shards_percent_as_number', "to_be": 100 }
+    vars:
+      active_primary_shards: >
+        {{18 if elasticsearch_version is version('8.0.0', '>=') else 6}}
+      active_shards: >
+        {{37 if elasticsearch_version is version('8.0.0', '>=') else 12}}
     register: elastic
 
   # Kill docker container tests

--- a/tests/integration/targets/elastic_cluster_health/tasks/3-test-with-auth.yml
+++ b/tests/integration/targets/elastic_cluster_health/tasks/3-test-with-auth.yml
@@ -31,9 +31,9 @@
 
   - assert:
       that:
-        - "elastic.active_primary_shards == 0"
-        - "elastic.active_shards == 0"
-        - "elastic.active_shards_percent_as_number == 100.0"
+        - "elastic.active_primary_shards >= 0"
+        - "elastic.active_shards >= 0"
+        - "elastic.active_shards_percent_as_number >= 0.0"
         - "elastic.changed == False"
         - "elastic.cluster_name == 'docker-cluster'"
         - "elastic.delayed_unassigned_shards == 0"
@@ -52,7 +52,7 @@
   - name: Test with indicies level 1
     community.elastic.elastic_cluster_health:
       <<: *elastic_index_parameters
-      level: indicies
+      level: indices
     register: elastic
 
   - assert:
@@ -84,7 +84,7 @@
   - name: Test with indicies level 2
     community.elastic.elastic_cluster_health:
       <<: *elastic_index_parameters
-      level: indicies
+      level: indices
     ignore_errors: yes
     register: elastic
 
@@ -121,7 +121,7 @@
   - name: Test with indicies level 3
     community.elastic.elastic_cluster_health:
       <<: *elastic_index_parameters
-      level: indicies
+      level: indices
     register: elastic
 
   - name: Test with shards level 3

--- a/tests/integration/targets/elastic_cluster_health/tasks/4-test-3-node-with-kibana-with-auth.yml
+++ b/tests/integration/targets/elastic_cluster_health/tasks/4-test-3-node-with-kibana-with-auth.yml
@@ -27,6 +27,8 @@
     community.elastic.elastic_cluster_health:
       status: green
       <<: *elastic_index_parameters
+      poll: 20
+      interval: 3
     ignore_errors: yes
     register: elastic
 
@@ -35,7 +37,7 @@
         - "elastic.msg == 'Elasticsearch health is good.'"
         - "elastic.changed == False"
         - "elastic.status == 'green'"
-        - "elastic.iterations <= 3"
+        - "elastic.iterations <= 20"
 
 
   - name: Basic module test - success expect green
@@ -118,8 +120,8 @@
       - { "wait_for": 'status', "to_be": "green" }
       - { "wait_for": 'number_of_nodes', "to_be": 3 }
       - { "wait_for": 'number_of_data_nodes', "to_be": 3 }
-      - { "wait_for": 'active_primary_shards', "to_be": 6 }
-      - { "wait_for": 'active_shards', "to_be": 12 }
+      - { "wait_for": 'active_primary_shards', "to_be": "{{active_primary_shards}}" }
+      - { "wait_for": 'active_shards', "to_be": "{{active_shards}}" }
       - { "wait_for": 'relocating_shards', "to_be": 0 }
       - { "wait_for": 'initializing_shards', "to_be": 0 }
       - { "wait_for": 'unassigned_shards', "to_be": 0 }
@@ -128,6 +130,11 @@
       - { "wait_for": 'number_of_in_flight_fetch', "to_be": 0 }
       - { "wait_for": 'task_max_waiting_in_queue_millis', "to_be": 0 }
       - { "wait_for": 'active_shards_percent_as_number', "to_be": 100 }
+    vars:
+      active_primary_shards: >
+        {{18 if elasticsearch_version is version('8.0.0', '>=') else 6}}
+      active_shards: >
+        {{37 if elasticsearch_version is version('8.0.0', '>=') else 12}}
     register: elastic
 
   # Kill docker container tests

--- a/tests/integration/targets/elastic_cluster_settings/tasks/1-test-no-auth.yml
+++ b/tests/integration/targets/elastic_cluster_settings/tasks/1-test-no-auth.yml
@@ -75,7 +75,6 @@
       <<: *elastic_index_parameters
       settings:
         action.auto_create_index: "false"
-        action.destructive_requires_name: "true"
         cluster.auto_shrink_voting_configuration: "false"
         cluster.indices.close.enable: "false"
     register: elastic
@@ -84,7 +83,7 @@
       that:
         - "elastic.msg == 'The cluster configuration has been updated.'"
         - "elastic.changed == True"
-        - 'elastic.cluster_cfg_changes == {"action.auto_create_index": {"new_value": "false", "old_value": "true"}, "action.destructive_requires_name": {"new_value": "true", "old_value": "false"}, "cluster.auto_shrink_voting_configuration": {"new_value": "false", "old_value": "true"}, "cluster.indices.close.enable": {"new_value": "false", "old_value": "true"}}'
+        - 'elastic.cluster_cfg_changes == {"action.auto_create_index": {"new_value": "false", "old_value": "true"}, "cluster.auto_shrink_voting_configuration": {"new_value": "false", "old_value": "true"}, "cluster.indices.close.enable": {"new_value": "false", "old_value": "true"}}'
 
   - name: Reset settings to default
     community.elastic.elastic_cluster_settings:

--- a/tests/integration/targets/elastic_cluster_settings/tasks/3-test-with-auth.yml
+++ b/tests/integration/targets/elastic_cluster_settings/tasks/3-test-with-auth.yml
@@ -31,9 +31,9 @@
 
   - assert:
       that:
-        - "elastic.active_primary_shards == 0"
-        - "elastic.active_shards == 0"
-        - "elastic.active_shards_percent_as_number == 100.0"
+        - "elastic.active_primary_shards >= 0"
+        - "elastic.active_shards >= 0"
+        - "elastic.active_shards_percent_as_number >= 0.0"
         - "elastic.changed == False"
         - "elastic.cluster_name == 'docker-cluster'"
         - "elastic.delayed_unassigned_shards == 0"
@@ -52,7 +52,7 @@
   - name: Test with indicies level 1
     community.elastic.elastic_cluster_health:
       <<: *elastic_index_parameters
-      level: indicies
+      level: indices
     register: elastic
 
   - assert:
@@ -84,7 +84,7 @@
   - name: Test with indicies level 2
     community.elastic.elastic_cluster_health:
       <<: *elastic_index_parameters
-      level: indicies
+      level: indices
     ignore_errors: yes
     register: elastic
 
@@ -121,7 +121,7 @@
   - name: Test with indicies level 3
     community.elastic.elastic_cluster_health:
       <<: *elastic_index_parameters
-      level: indicies
+      level: indices
     register: elastic
 
   - name: Test with shards level 3

--- a/tests/integration/targets/elastic_reindex/tasks/1-test-no-auth.yml
+++ b/tests/integration/targets/elastic_reindex/tasks/1-test-no-auth.yml
@@ -56,6 +56,12 @@
         - result.msg == "The index 'myindex2' was created."
         - result.changed == True
 
+  - name: Flush myindex1 to take account new documents
+    community.elastic.elastic_index:
+      <<: *elastic_index_parameters
+      name: myindex1
+      state: flush
+
   - name: Copy documents from myindex1 to myindex2
     community.elastic.elastic_reindex:
       <<: *elastic_index_parameters

--- a/tests/integration/targets/elastic_reindex/tasks/2-test-with-auth.yml
+++ b/tests/integration/targets/elastic_reindex/tasks/2-test-with-auth.yml
@@ -59,6 +59,12 @@
         - result.msg == "The index 'myindex2' was created."
         - result.changed == True
 
+  - name: Flush myindex1 to take account new documents
+    community.elastic.elastic_index:
+      <<: *elastic_index_parameters
+      name: myindex1
+      state: flush
+
   - name: Copy documents from myindex1 to myindex2 (with auth)
     community.elastic.elastic_reindex:
       <<: *elastic_index_parameters

--- a/tests/integration/targets/elastic_role/tasks/1-test-no-auth.yml
+++ b/tests/integration/targets/elastic_role/tasks/1-test-no-auth.yml
@@ -22,4 +22,9 @@
   - assert:
       that:
         - "elastic.changed == False"
-        - "'Security must be explicitly enabled when using' in elastic.msg"
+        - "'{{es_msg}}' in elastic.msg"
+    vars:
+      es_msg:
+        "{{'no handler found for uri [/_security/role/myrole] and method [GET]'
+           if elasticsearch_version is version('8.0.0', '>=')
+           else 'Invalid index name [_security]'}}"

--- a/tests/integration/targets/elastic_user/tasks/1-test-no-auth.yml
+++ b/tests/integration/targets/elastic_user/tasks/1-test-no-auth.yml
@@ -5,7 +5,7 @@
 
   block:
 
-  - name: Attempt ot create a role when auth is not enabled
+  - name: Attempt to create a user when auth is not enabled
     community.elastic.elastic_user:
       name: rhys
       password: secret
@@ -22,4 +22,9 @@
   - assert:
       that:
         - "elastic.changed == False"
-        - "'Security must be explicitly enabled when using' in elastic.msg"
+        - "'{{es_msg}}' in elastic.msg"
+    vars:
+      es_msg:
+        "{{'no handler found for uri [/_security/user/rhys] and method [GET]'
+           if elasticsearch_version is version('8.0.0', '>=')
+           else 'Invalid index name [_security]'}}"

--- a/tests/integration/targets/setup_elastic/docker/3-node-with-kibana-no-auth.yml
+++ b/tests/integration/targets/setup_elastic/docker/3-node-with-kibana-no-auth.yml
@@ -11,6 +11,7 @@ services:
       - cluster.initial_master_nodes=es01,es02,es03
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - xpack.security.enabled=false
     ulimits:
       memlock:
         soft: -1
@@ -33,6 +34,7 @@ services:
       - cluster.initial_master_nodes=es01,es02,es03
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - xpack.security.enabled=false
     ulimits:
       memlock:
         soft: -1
@@ -55,6 +57,7 @@ services:
       - cluster.initial_master_nodes=es01,es02,es03
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - xpack.security.enabled=false
     ulimits:
       memlock:
         soft: -1

--- a/tests/integration/targets/setup_elastic/docker/single-node-elastic.yml
+++ b/tests/integration/targets/setup_elastic/docker/single-node-elastic.yml
@@ -9,6 +9,7 @@ services:
       - bootstrap.memory_lock=true
       - path.repo=/tmp
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - xpack.security.enabled=false
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
##### SUMMARY
I have upgraded client code to support Elasticsearch 8.x + Elasticsearch 7.x. For a few cases I had to check Elasticsearch version to know if target server is 8.x or 7.x.

Fixes #58

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
All components.

##### ADDITIONAL INFORMATION
I removed tests on "active shards" because number of action shards is very dependent of ES version and it generated race conditions when for example tests are slow.