### PR TITLE
Fixes for self-signed certs: Disable verify and cafile fix.

### DIFF
--- a/.github/workflows/publish_collection.yml
+++ b/.github/workflows/publish_collection.yml
@@ -31,27 +31,27 @@ jobs:
       - name: Rename the build artifact
         run: mv community-elastic-*.tar.gz community-elastic-latest.tar.gz
 
-#      - name: Upload community-elastic-latest.tar.gz as an artifact
-#        uses: actions/upload-artifact@v1
-#        with:
-#          name: community-elastic-latest
-#          path: ansible_collections/community/elastic/community-elastic-latest.tar.gz
-#
-#      # Moving the tag leaves an orphan artifact. Just changing the artifact doesn't move the tag.
-#      - name: Delete latest tag and release
-#        uses: dev-drprasad/delete-tag-and-release@v1.0.1
-#        with:
-#          delete_release: true
-#          tag_name: latest
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#
-#      - name: Upload files to release
-#        uses: svenstaro/upload-release-action@v2
-#        with:
-#          repo_token: ${{ secrets.GITHUB_TOKEN }}
-#          file: ansible_collections/community/elastic/community-elastic-latest.tar.gz
-#          asset_name: community-elastic-latest.tar.gz
-#          body: "Development release"
-#          tag: latest
-#          overwrite: true
+      - name: Upload community-elastic-latest.tar.gz as an artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: community-elastic-latest
+          path: ansible_collections/community/elastic/community-elastic-latest.tar.gz
+
+      # Moving the tag leaves an orphan artifact. Just changing the artifact doesn't move the tag.
+      - name: Delete latest tag and release
+        uses: dev-drprasad/delete-tag-and-release@v1.0.1
+        with:
+          delete_release: true
+          tag_name: latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload files to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ansible_collections/community/elastic/community-elastic-latest.tar.gz
+          asset_name: community-elastic-latest.tar.gz
+          body: "Development release"
+          tag: latest
+          overwrite: true

--- a/.github/workflows/publish_collection.yml
+++ b/.github/workflows/publish_collection.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   build_publish:
-
     runs-on: ubuntu-20.04
     defaults:
       run:

--- a/.github/workflows/publish_collection.yml
+++ b/.github/workflows/publish_collection.yml
@@ -31,27 +31,27 @@ jobs:
       - name: Rename the build artifact
         run: mv community-elastic-*.tar.gz community-elastic-latest.tar.gz
 
-      - name: Upload community-elastic-latest.tar.gz as an artifact
-        uses: actions/upload-artifact@v1
-        with:
-          name: community-elastic-latest
-          path: ansible_collections/community/elastic/community-elastic-latest.tar.gz
-
-      # Moving the tag leaves an orphan artifact. Just changing the artifact doesn't move the tag.
-      - name: Delete latest tag and release
-        uses: dev-drprasad/delete-tag-and-release@v1.0.1
-        with:
-          delete_release: true
-          tag_name: latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload files to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ansible_collections/community/elastic/community-elastic-latest.tar.gz
-          asset_name: community-elastic-latest.tar.gz
-          body: "Development release"
-          tag: latest
-          overwrite: true
+#      - name: Upload community-elastic-latest.tar.gz as an artifact
+#        uses: actions/upload-artifact@v1
+#        with:
+#          name: community-elastic-latest
+#          path: ansible_collections/community/elastic/community-elastic-latest.tar.gz
+#
+#      # Moving the tag leaves an orphan artifact. Just changing the artifact doesn't move the tag.
+#      - name: Delete latest tag and release
+#        uses: dev-drprasad/delete-tag-and-release@v1.0.1
+#        with:
+#          delete_release: true
+#          tag_name: latest
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#
+#      - name: Upload files to release
+#        uses: svenstaro/upload-release-action@v2
+#        with:
+#          repo_token: ${{ secrets.GITHUB_TOKEN }}
+#          file: ansible_collections/community/elastic/community-elastic-latest.tar.gz
+#          asset_name: community-elastic-latest.tar.gz
+#          body: "Development release"
+#          tag: latest
+#          overwrite: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,15 +1,15 @@
-name: 'Close stale issues and PRs'
-on:
-  schedule:
-    - cron: '30 1 * * *'
-
-jobs:
-  stale:
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Close Stale Issues
-        uses: actions/stale@v5.0.0
-        with:
-          exempt-issue-labels: 'nostale,bug,help-wanted,feature,pinboard'
-          exempt-pr-labels: 'nostale,bug,help-wanted,feature'
+#name: 'Close stale issues and PRs'
+#on:
+#  schedule:
+#    - cron: '30 1 * * *'
+#
+#jobs:
+#  stale:
+#    runs-on: ubuntu-latest
+#    steps:
+#
+#      - name: Close Stale Issues
+#        uses: actions/stale@v5.0.0
+#        with:
+#          exempt-issue-labels: 'nostale,bug,help-wanted,feature,pinboard'
+#          exempt-pr-labels: 'nostale,bug,help-wanted,feature'

--- a/plugins/doc_fragments/login_options.py
+++ b/plugins/doc_fragments/login_options.py
@@ -29,7 +29,7 @@ options:
   connection_options:
     description:
       - Additional connection options for Elasticsearch
-    type: list
+    type: dict
     elements: dict
     default: []
   login_user:

--- a/plugins/modules/elastic_role.py
+++ b/plugins/modules/elastic_role.py
@@ -97,6 +97,8 @@ EXAMPLES = r'''
       - reporting_user
     metadata:
       comment: "System admin role"
+    connection_options:
+      verify_certs: false
 '''
 
 RETURN = r'''

--- a/tests/integration/targets/elastic_role/tasks/2-test-with-auth.yml
+++ b/tests/integration/targets/elastic_role/tasks/2-test-with-auth.yml
@@ -75,6 +75,72 @@
       - "elastic.changed"
       - elastic.msg == 'The role myrole was deleted.'
 
+- name: Create a simple role with verify_cert=False
+  community.elastic.elastic_role:
+    name: myrole
+    state: present
+    connection_options:
+      verify_cert: false
+    indices:
+      - names:
+          - "index1"
+          - "index2"
+        privileges:
+          - "all"
+    <<: *elastic_index_parameters
+  register: elastic
+
+- assert:
+    that:
+      - "elastic.changed"
+      - "'The role myrole was successfully created' in elastic.msg"
+
+- name: Delete the role with verify_cert=False
+  community.elastic.elastic_role:
+    name: myrole
+    state: absent
+    connection_options:
+      verify_cert: false
+    <<: *elastic_index_parameters
+  register: elastic
+
+- assert:
+    that:
+      - "elastic.changed"
+      - elastic.msg == 'The role myrole was deleted.'
+
+- name: Create a simple role cafile
+  community.elastic.elastic_role:
+    name: myrole
+    state: present
+    cafile: "cacert-example.pem"
+    indices:
+      - names:
+          - "index1"
+          - "index2"
+        privileges:
+          - "all"
+    <<: *elastic_index_parameters
+  register: elastic
+
+- assert:
+    that:
+      - "elastic.changed"
+      - "'The role myrole was successfully created' in elastic.msg"
+
+- name: Delete the role with cafile
+  community.elastic.elastic_role:
+    name: myrole
+    state: absent
+    cafile: "cacert-example.pem"
+    <<: *elastic_index_parameters
+  register: elastic
+
+- assert:
+    that:
+      - "elastic.changed"
+      - elastic.msg == 'The role myrole was deleted.'
+
 - name: Add a new role with check mode
   community.elastic.elastic_role:
     name: myrole

--- a/tests/integration/targets/elastic_role/tasks/cacert-example.pem
+++ b/tests/integration/targets/elastic_role/tasks/cacert-example.pem
@@ -1,0 +1,199 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 9159228328959137200 (0x7f1c1da3344dd5b0)
+        Signature Algorithm: sha512WithRSAEncryption
+        Issuer: C=US, ST=DC, L=Washington, O=ExampleCorp, CN=example.com/emailAddress=user@example.com
+        Validity
+            Not Before: Apr 23 22:24:45 2024 GMT
+            Not After : Jan  6 17:18:05 2038 GMT
+        Subject: C=US, ST=DC, L=Washington, O=ExampleCorp, CN=example.com/emailAddress=user@example.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (8192 bit)
+                Modulus:
+                    00:b4:40:ba:5a:b6:3c:a3:38:7c:a1:3a:b8:ca:b5:
+                    e4:d0:dc:4f:03:4a:ea:1c:4b:dd:64:ff:02:37:93:
+                    2c:f9:20:1a:57:66:e9:25:c8:9d:d3:68:61:54:b9:
+                    ee:4c:69:ae:66:76:69:85:be:64:fb:7b:2b:c8:37:
+                    db:db:22:9c:69:df:11:91:cc:58:48:1b:67:d7:23:
+                    fb:a4:b8:e8:e0:51:2d:5f:28:65:68:ff:bf:58:6c:
+                    ee:c0:95:b4:70:52:9b:7a:fd:25:f5:ff:8f:04:6a:
+                    b1:5a:48:51:3a:87:9b:53:50:85:ea:b1:b4:db:fe:
+                    2e:e4:a5:bf:7d:3a:92:01:99:00:53:2e:d7:ac:2e:
+                    08:9f:23:19:75:30:e0:cd:8a:63:0a:3a:35:ac:8f:
+                    10:b8:e0:d2:02:8f:c1:75:10:87:2d:79:8c:aa:5a:
+                    83:76:3c:33:b7:8c:78:df:10:53:01:93:d7:8a:dd:
+                    f5:f7:bc:66:a7:80:dd:d6:32:c9:6c:ae:49:1b:2a:
+                    64:9c:a0:f4:52:c5:d4:ba:fc:ec:ac:34:33:ea:46:
+                    81:d4:4f:42:13:68:68:e7:43:a6:48:19:aa:7a:39:
+                    74:ab:e7:b4:40:38:84:72:e8:13:45:e5:73:3d:5a:
+                    44:c7:cf:d3:1b:f0:9b:d2:f7:0c:a3:18:1b:7c:cb:
+                    c2:ba:49:93:56:7c:eb:69:92:9d:5a:84:43:69:2c:
+                    89:76:bc:cc:4e:b8:09:c5:52:de:ac:63:aa:8a:3a:
+                    6e:c7:89:39:21:d9:f9:e8:8b:0b:fc:80:bd:f0:18:
+                    9c:90:ca:cc:7e:9b:b7:4c:7f:dd:5c:30:72:4b:0b:
+                    1b:f8:3c:60:7a:ea:06:6c:21:de:9e:f0:22:5a:56:
+                    05:00:11:d1:7a:7f:dd:f2:a9:4e:e7:ec:a8:11:61:
+                    5d:2b:62:65:f3:04:a9:d5:31:f0:9a:e5:4e:fc:a0:
+                    05:9f:f5:b8:4b:df:7d:21:b6:e0:73:a9:de:fa:1c:
+                    f9:d7:f0:20:99:0f:33:85:a0:24:55:a7:ff:bd:6c:
+                    13:89:39:e5:3a:14:b0:83:6d:fd:66:96:93:72:be:
+                    43:2a:72:03:a4:b1:91:10:09:4a:0d:9d:cc:71:8e:
+                    2e:24:63:25:38:c3:6e:49:2f:00:97:ad:07:33:a8:
+                    da:27:1c:52:ea:37:58:8e:37:b7:59:8b:0f:51:8e:
+                    19:78:49:94:90:b1:a3:b9:7f:34:08:4b:b0:75:40:
+                    47:d1:a6:cd:eb:1d:6a:4a:a9:45:bc:a1:73:bc:6d:
+                    a3:8d:e4:5e:7b:63:a4:23:8c:f6:d6:62:79:f0:8d:
+                    52:96:48:45:48:81:4f:a8:c3:dc:a6:74:b1:28:b4:
+                    f6:60:34:75:1b:fc:29:d0:76:3e:08:2a:87:e0:45:
+                    c8:b7:ce:f0:6b:78:2e:f9:f5:11:3f:d1:2f:9d:df:
+                    85:e0:cf:97:64:aa:19:e5:ae:8a:65:6d:1c:70:eb:
+                    7a:61:35:ff:6c:c9:95:2b:6d:f7:2b:93:2b:49:70:
+                    47:43:1a:67:33:cf:89:09:e7:e8:8f:2d:8d:c6:15:
+                    45:aa:88:96:5e:1e:5e:b3:f9:ba:bb:57:81:30:1f:
+                    48:02:4b:9b:d3:da:e3:a6:6c:e2:b7:09:e4:23:1d:
+                    50:d6:85:fb:5e:21:d2:bb:4c:4e:ac:9c:4d:07:29:
+                    5d:d1:1b:bf:73:d9:ab:7c:ca:76:38:4c:83:8f:06:
+                    40:ae:3a:09:65:90:e6:0a:81:d9:ce:0f:0b:39:fe:
+                    b6:d7:a7:63:49:3c:83:d5:c4:9b:76:b7:e3:6d:ff:
+                    16:aa:c3:fa:d4:c6:f5:a2:07:49:a8:d2:aa:e6:a7:
+                    5a:40:08:cf:b6:35:c2:75:5f:04:ab:2d:f6:bc:36:
+                    34:3c:71:22:b2:54:af:e6:96:dd:96:67:2d:42:68:
+                    8b:1c:5a:48:21:78:9b:71:9e:9d:97:ec:f5:81:0e:
+                    cc:cd:6a:0d:86:c4:eb:e4:87:63:35:8e:06:78:20:
+                    55:05:be:4f:92:89:0a:3c:23:29:fe:2f:0b:7c:0d:
+                    89:ab:58:14:df:56:d9:23:f3:8e:55:0a:09:47:32:
+                    0e:77:68:4c:1b:22:09:e4:27:43:9c:93:59:3a:71:
+                    f3:e0:4b:9c:64:95:24:d7:16:49:2b:41:b9:55:87:
+                    4f:eb:92:00:94:bf:a6:ae:08:c9:40:6a:f6:94:87:
+                    cd:5d:16:57:e7:91:ee:55:e8:61:a3:c5:15:30:66:
+                    61:d6:d2:09:08:d5:df:8d:b3:cb:d9:85:4e:20:1b:
+                    91:57:4f:6d:c5:74:f0:88:68:d3:86:01:7c:d8:0c:
+                    f4:e9:43:4c:25:36:28:a0:09:c4:ee:20:9f:14:8f:
+                    eb:71:0f:69:b3:8d:7f:df:d9:ce:fd:db:35:f2:ab:
+                    e1:27:1e:ea:98:c8:d5:8a:c6:c6:1e:49:df:9c:72:
+                    0b:65:9c:02:87:e9:62:2f:79:31:a1:3d:8c:16:28:
+                    aa:c8:60:dd:b2:b9:a5:0f:a6:f8:7b:7e:44:88:f1:
+                    99:88:73:45:ab:b1:f4:43:31:e1:9b:95:79:3b:82:
+                    9f:65:93:bb:29:f9:14:ac:e3:36:e5:18:29:ac:fe:
+                    05:46:e0:41:ed:3e:3b:fa:96:e2:a9:b6:a4:b7:31:
+                    ae:61:ce:5d:84:1b:a9:b4:14:5e:cb:7f:07:12:23:
+                    1a:07:1a:b8:b5:a6:5c:34:84:b6:96:77:ae:74:f8:
+                    5e:6e:a8:f8:87
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints: 
+                CA:TRUE
+    Signature Algorithm: sha512WithRSAEncryption
+    Signature Value:
+        37:9c:39:a0:d7:5f:6b:87:0f:fa:f7:d0:34:ab:4a:6e:a2:99:
+        c0:0b:41:f3:ad:67:50:0a:11:8b:be:9e:22:d3:6d:6e:8a:3d:
+        19:05:e4:2f:dc:02:03:3c:7e:12:ff:fc:29:3b:9f:13:52:67:
+        f4:77:3e:48:ef:30:44:bc:ac:dd:56:48:ab:47:3a:f2:b0:a6:
+        a7:2a:ee:81:f0:93:60:07:94:7b:7e:21:92:3d:ae:68:4f:87:
+        76:04:5c:60:9e:8c:19:49:b1:36:8d:82:5b:44:ff:72:39:c4:
+        dc:cd:ce:39:ea:af:3b:f7:e7:17:c9:60:10:31:24:f3:0c:81:
+        b7:61:79:12:30:11:0f:df:f8:3e:47:78:5d:53:93:fd:12:7e:
+        31:b0:72:d5:4b:6a:4c:23:87:0f:fd:04:3a:c8:74:61:d1:f9:
+        6e:14:76:b4:88:eb:a9:9a:3a:ae:43:76:e5:9c:48:68:12:01:
+        d8:64:62:6e:76:f8:f4:b0:e5:7a:7f:a1:3b:aa:0e:40:4d:67:
+        c3:f2:61:a8:0a:84:9e:f9:92:08:33:08:43:a3:c0:eb:7d:f1:
+        56:1b:2e:45:b9:bd:c6:fa:76:1d:68:c1:a9:c8:b5:2d:9c:fa:
+        01:a6:7b:dd:8e:e9:c9:3b:9c:a9:d9:60:93:43:22:9f:c2:41:
+        b7:c9:6a:03:b1:a1:a0:d0:e5:a7:0a:05:b9:f5:f4:74:99:2e:
+        50:60:9d:81:fd:a2:f0:46:ac:6d:a7:c7:88:75:45:fc:5a:83:
+        93:d7:41:a9:3f:4a:96:a1:10:02:0d:e3:52:84:b1:0f:1a:d4:
+        ea:59:2f:cc:d4:93:70:9c:1b:d6:6b:17:f3:18:02:f8:7d:15:
+        7f:ff:19:1d:54:4f:90:5f:6a:dd:b3:8e:ce:5f:2a:d1:59:0e:
+        24:e6:da:22:4b:53:60:54:69:4b:6a:8b:04:2b:66:b3:c4:ee:
+        92:7b:23:ba:e0:8f:2c:73:5a:89:7a:e9:cb:00:2f:8e:2c:3c:
+        01:52:60:d9:46:dc:7e:11:7e:88:e6:b1:1e:5f:f5:75:2e:f7:
+        bc:27:d9:a0:79:cc:43:4b:13:08:20:b8:e9:7d:4f:d7:c7:1c:
+        bc:ea:1f:44:73:a6:57:3f:06:ff:81:00:85:cf:93:a9:18:5c:
+        81:10:c5:18:0e:19:b6:a5:26:21:c1:37:05:f1:12:eb:33:02:
+        80:91:1c:60:58:32:48:fd:c2:f3:56:2e:ff:6e:34:53:08:be:
+        53:1b:f5:ac:ff:86:08:54:ae:61:c8:6e:98:8f:fc:62:b4:52:
+        21:11:94:e3:0e:09:a6:53:d4:2b:d7:26:aa:90:25:ac:5d:e4:
+        cd:c5:37:92:a9:e4:2b:ad:80:83:9f:0b:60:5f:64:8d:94:9c:
+        81:89:f2:49:d8:ed:fb:63:63:87:17:6e:12:c9:0e:f6:eb:33:
+        2b:e1:6d:a0:86:c0:30:a5:e3:9c:89:30:3a:16:80:a3:3a:a8:
+        42:4b:71:15:fd:4a:32:6c:47:da:cd:9a:6a:81:fd:9e:91:60:
+        da:0e:06:83:da:1c:3b:ed:ff:72:f3:11:ab:26:aa:11:9e:59:
+        41:1e:8d:13:85:e9:ba:b0:e3:ea:bf:80:41:08:39:81:12:1d:
+        bf:32:e9:e2:c5:24:99:b6:71:17:67:bd:19:ee:1b:8c:39:0f:
+        0e:c6:34:6f:40:e2:9f:bd:d8:42:34:29:8a:e9:fd:b8:90:a1:
+        6f:14:c6:13:b0:3d:3f:c6:62:75:c2:8e:a7:d5:04:ea:a6:3a:
+        fa:ff:da:76:3e:a2:2c:df:d5:0e:ba:7c:2f:4f:42:20:d0:a1:
+        6f:cc:c8:6f:f1:4d:ea:43:0e:ed:c9:28:2c:b9:e7:f6:e1:f3:
+        e5:1c:82:3f:3d:3c:3b:29:4e:78:b5:7e:88:7c:e3:a2:1b:58:
+        fc:b7:4b:06:fc:32:9f:a4:dd:48:86:73:45:88:b8:c2:31:5e:
+        d6:6c:bf:06:bc:e8:08:b8:cf:9c:95:ec:51:f8:82:ba:f3:3d:
+        19:35:3f:7b:b6:1c:25:34:4c:e2:64:38:da:3e:c0:54:fd:c3:
+        6c:38:88:9e:c2:5d:3e:12:2a:36:c4:2e:6b:67:57:94:a3:8a:
+        04:4e:82:cf:06:e1:9c:f8:5e:4c:91:28:2d:03:11:30:17:0c:
+        a0:de:cd:fb:56:30:c0:ba:c4:b8:56:86:fc:a8:99:b1:27:21:
+        4b:90:02:d5:a1:1d:9f:8d:83:34:74:d4:21:e4:77:4e:f5:e6:
+        24:84:c8:78:1b:de:34:18:9d:3b:8f:7a:20:a3:b0:7b:de:4e:
+        d6:38:7a:8b:06:65:1c:1b:ed:32:c3:f5:db:ff:32:e5:0e:91:
+        8e:63:68:a9:62:90:91:ac:c0:74:f8:7b:e1:cd:57:d0:5c:9b:
+        ca:03:9a:33:ee:58:e6:ec:06:a5:39:f9:85:df:fa:ef:aa:b4:
+        f1:27:73:33:45:c1:7c:0b:19:5d:fa:29:4e:d0:05:d6:5d:9b:
+        9d:a8:b6:29:33:14:ec:cf:7d:02:77:dc:e8:ed:8e:ee:db:8f:
+        2c:4f:c8:d6:2e:90:9d:fe:25:93:58:eb:68:44:9a:ab:b4:58:
+        8a:8c:d0:7d:ee:54:4e:59:cb:be:81:2b:29:f9:2c:96:e4:65:
+        b1:91:6b:f2:ee:04:05:88:f3:39:db:6d:b8:34:a0:7e:e2:19:
+        d8:79:7c:e3:36:d9:53:b3:83:e9:9d:6e:3d:41:95:27
+-----BEGIN CERTIFICATE-----
+MIIJijCCBXKgAwIBAgIIfxwdozRN1bAwDQYJKoZIhvcNAQENBQAwfDELMAkGA1UE
+BhMCVVMxCzAJBgNVBAgMAkRDMRMwEQYDVQQHDApXYXNoaW5ndG9uMRQwEgYDVQQK
+DAtFeGFtcGxlQ29ycDEUMBIGA1UEAwwLZXhhbXBsZS5jb20xHzAdBgkqhkiG9w0B
+CQEWEHVzZXJAZXhhbXBsZS5jb20wHhcNMjQwNDIzMjIyNDQ1WhcNMzgwMTA2MTcx
+ODA1WjB8MQswCQYDVQQGEwJVUzELMAkGA1UECAwCREMxEzARBgNVBAcMCldhc2hp
+bmd0b24xFDASBgNVBAoMC0V4YW1wbGVDb3JwMRQwEgYDVQQDDAtleGFtcGxlLmNv
+bTEfMB0GCSqGSIb3DQEJARYQdXNlckBleGFtcGxlLmNvbTCCBCIwDQYJKoZIhvcN
+AQEBBQADggQPADCCBAoCggQBALRAulq2PKM4fKE6uMq15NDcTwNK6hxL3WT/AjeT
+LPkgGldm6SXIndNoYVS57kxprmZ2aYW+ZPt7K8g329sinGnfEZHMWEgbZ9cj+6S4
+6OBRLV8oZWj/v1hs7sCVtHBSm3r9JfX/jwRqsVpIUTqHm1NQheqxtNv+LuSlv306
+kgGZAFMu16wuCJ8jGXUw4M2KYwo6NayPELjg0gKPwXUQhy15jKpag3Y8M7eMeN8Q
+UwGT14rd9fe8ZqeA3dYyyWyuSRsqZJyg9FLF1Lr87Kw0M+pGgdRPQhNoaOdDpkgZ
+qno5dKvntEA4hHLoE0Xlcz1aRMfP0xvwm9L3DKMYG3zLwrpJk1Z862mSnVqEQ2ks
+iXa8zE64CcVS3qxjqoo6bseJOSHZ+eiLC/yAvfAYnJDKzH6bt0x/3VwwcksLG/g8
+YHrqBmwh3p7wIlpWBQAR0Xp/3fKpTufsqBFhXStiZfMEqdUx8JrlTvygBZ/1uEvf
+fSG24HOp3voc+dfwIJkPM4WgJFWn/71sE4k55ToUsINt/WaWk3K+QypyA6SxkRAJ
+Sg2dzHGOLiRjJTjDbkkvAJetBzOo2iccUuo3WI43t1mLD1GOGXhJlJCxo7l/NAhL
+sHVAR9GmzesdakqpRbyhc7xto43kXntjpCOM9tZiefCNUpZIRUiBT6jD3KZ0sSi0
+9mA0dRv8KdB2Pggqh+BFyLfO8Gt4Lvn1ET/RL53fheDPl2SqGeWuimVtHHDremE1
+/2zJlStt9yuTK0lwR0MaZzPPiQnn6I8tjcYVRaqIll4eXrP5urtXgTAfSAJLm9Pa
+46Zs4rcJ5CMdUNaF+14h0rtMTqycTQcpXdEbv3PZq3zKdjhMg48GQK46CWWQ5gqB
+2c4PCzn+ttenY0k8g9XEm3a3423/FqrD+tTG9aIHSajSquanWkAIz7Y1wnVfBKst
+9rw2NDxxIrJUr+aW3ZZnLUJoixxaSCF4m3GenZfs9YEOzM1qDYbE6+SHYzWOBngg
+VQW+T5KJCjwjKf4vC3wNiatYFN9W2SPzjlUKCUcyDndoTBsiCeQnQ5yTWTpx8+BL
+nGSVJNcWSStBuVWHT+uSAJS/pq4IyUBq9pSHzV0WV+eR7lXoYaPFFTBmYdbSCQjV
+342zy9mFTiAbkVdPbcV08Iho04YBfNgM9OlDTCU2KKAJxO4gnxSP63EPabONf9/Z
+zv3bNfKr4Sce6pjI1YrGxh5J35xyC2WcAofpYi95MaE9jBYoqshg3bK5pQ+m+Ht+
+RIjxmYhzRaux9EMx4ZuVeTuCn2WTuyn5FKzjNuUYKaz+BUbgQe0+O/qW4qm2pLcx
+rmHOXYQbqbQUXst/BxIjGgcauLWmXDSEtpZ3rnT4Xm6o+IcCAwEAAaMQMA4wDAYD
+VR0TBAUwAwEB/zANBgkqhkiG9w0BAQ0FAAOCBAEAN5w5oNdfa4cP+vfQNKtKbqKZ
+wAtB861nUAoRi76eItNtboo9GQXkL9wCAzx+Ev/8KTufE1Jn9Hc+SO8wRLys3VZI
+q0c68rCmpyrugfCTYAeUe34hkj2uaE+HdgRcYJ6MGUmxNo2CW0T/cjnE3M3OOeqv
+O/fnF8lgEDEk8wyBt2F5EjARD9/4Pkd4XVOT/RJ+MbBy1UtqTCOHD/0EOsh0YdH5
+bhR2tIjrqZo6rkN25ZxIaBIB2GRibnb49LDlen+hO6oOQE1nw/JhqAqEnvmSCDMI
+Q6PA633xVhsuRbm9xvp2HWjBqci1LZz6AaZ73Y7pyTucqdlgk0Min8JBt8lqA7Gh
+oNDlpwoFufX0dJkuUGCdgf2i8EasbafHiHVF/FqDk9dBqT9KlqEQAg3jUoSxDxrU
+6lkvzNSTcJwb1msX8xgC+H0Vf/8ZHVRPkF9q3bOOzl8q0VkOJObaIktTYFRpS2qL
+BCtms8TuknsjuuCPLHNaiXrpywAvjiw8AVJg2UbcfhF+iOaxHl/1dS73vCfZoHnM
+Q0sTCCC46X1P18ccvOofRHOmVz8G/4EAhc+TqRhcgRDFGA4ZtqUmIcE3BfES6zMC
+gJEcYFgySP3C81Yu/240Uwi+Uxv1rP+GCFSuYchumI/8YrRSIRGU4w4JplPUK9cm
+qpAlrF3kzcU3kqnkK62Ag58LYF9kjZScgYnySdjt+2NjhxduEskO9uszK+FtoIbA
+MKXjnIkwOhaAozqoQktxFf1KMmxH2s2aaoH9npFg2g4Gg9ocO+3/cvMRqyaqEZ5Z
+QR6NE4XpurDj6r+AQQg5gRIdvzLp4sUkmbZxF2e9Ge4bjDkPDsY0b0Din73YQjQp
+iun9uJChbxTGE7A9P8ZidcKOp9UE6qY6+v/adj6iLN/VDrp8L09CINChb8zIb/FN
+6kMO7ckoLLnn9uHz5RyCPz08OylOeLV+iHzjohtY/LdLBvwyn6TdSIZzRYi4wjFe
+1my/BrzoCLjPnJXsUfiCuvM9GTU/e7YcJTRM4mQ42j7AVP3DbDiInsJdPhIqNsQu
+a2dXlKOKBE6CzwbhnPheTJEoLQMRMBcMoN7N+1YwwLrEuFaG/KiZsSchS5AC1aEd
+n42DNHTUIeR3TvXmJITIeBveNBidO496IKOwe95O1jh6iwZlHBvtMsP12/8y5Q6R
+jmNoqWKQkazAdPh74c1X0FybygOaM+5Y5uwGpTn5hd/676q08SdzM0XBfAsZXfop
+TtAF1l2bnai2KTMU7M99Anfc6O2O7tuPLE/I1i6Qnf4lk1jraESaq7RYiozQfe5U
+TlnLvoErKfksluRlsZFr8u4EBYjzOdttuDSgfuIZ2Hl84zbZU7OD6Z1uPUGVJw==
+-----END CERTIFICATE-----


### PR DESCRIPTION
As referenced in upstream issue #64 (see below), the "cafile" option seems to have an issue with the Python code for setting the cafile in the SSL context.

Additionally, the code for "connection_options" was incorrect, and so you couldn't use it to disable the verification.  This also has a fix for that and an example of how to use it.

https://github.com/ansible-collections/community.elastic/issues/64

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

As referenced in upstream issue #64 (see below), the "cafile" option seems to have an issue with the Python code for setting the cafile in the SSL context.

Additionally, the code for "connection_options" was incorrect, and so you couldn't use it to disable the verification.  This also has a fix for that and an example of how to use it.

Fixes #64 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
elastic_common.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

As documented in #64 