### PR TITLE
ApiKey: Add ApiKey authentication.

### DIFF
--- a/plugins/doc_fragments/login_options.py
+++ b/plugins/doc_fragments/login_options.py
@@ -13,6 +13,7 @@ options:
     choices:
        - ''
        - http_auth
+       - api_key
     default: ''
   auth_scheme:
     description:
@@ -57,6 +58,9 @@ options:
     required: no
     type: int
     default: 9200
+  api_key:
+    description:
+      - The ApiKey to authenticate with the server.
   timeout:
     description:
       - Response timeout in seconds.

--- a/plugins/module_utils/elastic_common.py
+++ b/plugins/module_utils/elastic_common.py
@@ -27,9 +27,10 @@ def elastic_common_argument_spec():
     Returns a dict containing common options shared across the elastic modules
     """
     options = dict(
-        auth_method=dict(type='str', choices=['', 'http_auth'], default=''),
+        auth_method=dict(type='str', choices=['', 'http_auth', 'api_key'], default=''),
         auth_scheme=dict(type='str', choices=['http', 'https'], default='http'),
         cafile=dict(type='str', default=None),
+        api_key=dict(type='str', default=None),
         connection_options=dict(type='list', elements='dict', default=[]),
         login_user=dict(type='str', required=False),
         login_password=dict(type='str', required=False, no_log=True),
@@ -53,17 +54,25 @@ class ElasticHelpers():
         Build the auth list for elastic according to the passed in parameters
         '''
         auth = {}
-        if module.params['auth_method'] != '':
-            if module.params['auth_method'] == 'http_auth':
-                auth["http_auth"] = (module.params['login_user'],
-                                     module.params['login_password'])
+        if not module.params['auth_method']:
+            return auth
 
-                if module.params['cafile'] is not None:
-                    from ssl import create_default_context
-                    context = create_default_context(module.params['cafile'])
-                    auth["ssl_context"] = context
-            else:
-                module.fail_json("Invalid or unsupported auth_method provided")
+        if module.params['auth_method'] == 'http_auth':
+            # username/password authentication.
+            auth["http_auth"] = (module.params['login_user'],
+                                 module.params['login_password'])
+        elif module.params['auth_method'] == 'api_key':
+            # api key authentication.
+            auth["api_key"] = module.params['api_key']
+        else:
+            module.fail_json("Invalid or unsupported auth_method provided")
+
+        # CA file has been provided. Add it to auth dict
+        if module.params['cafile'] is not None:
+            from ssl import create_default_context
+            context = create_default_context(module.params['cafile'])
+            auth["ssl_context"] = context
+
         return auth
 
     def connect(self):


### PR DESCRIPTION
##### SUMMARY

This PR adds "api_key" authentication for elastic search clusters. This is a necessary feature for when Elasticsearch is not managed via user/password combination.


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
 - elastic/plugins/module_utils/elastic_common.py

##### ADDITIONAL INFORMATION

It adds **api_key** as a auth_method but also a value.

```yaml

- name: Update ElasticSearch cluster settings
  hosts: localhost
  tasks:
    - name: "Updating {{ zone }} cluster settings"
      community.elastic.elastic_cluster_settings:
        persistent: true
        login_hosts: "some_host"
        login_port: 443
        auth_method: api_key
        api_key: "some_key"
        auth_scheme: "https"
        settings:
          action.auto_create_index: "-dp*,+*"
```
