### PR TITLE
Allow manual specification of login host connection url.

### DIFF
--- a/plugins/doc_fragments/login_options.py
+++ b/plugins/doc_fragments/login_options.py
@@ -48,6 +48,8 @@ options:
   login_hosts:
     description:
       - The Elastic hosts to connect to.
+      - Can accept hostnames or URLs. If a hostname then values\
+        login_port and login_scheme will be used to construct a URL.
     required: no
     type: list
     elements: str

--- a/plugins/module_utils/elastic_common.py
+++ b/plugins/module_utils/elastic_common.py
@@ -3,13 +3,17 @@ __metaclass__ = type
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib  # pylint: disable=unused-import
 
 import traceback
-import urllib.parse
 
 elastic_found = False
 E_IMP_ERR = None
 NotFoundError = None
 helpers = None
 __version__ = None
+
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 try:
     from elasticsearch import Elasticsearch
@@ -55,7 +59,7 @@ class ElasticHelpers():
         Given a host, build a connection url using default
         fragments if the host isnot already a valid url.
         '''
-        host_url = urllib.parse.urlparse(host)
+        host_url = urlparse(host)
         if host_url.scheme and host_url.netloc:
             return host
 

--- a/plugins/module_utils/elastic_common.py
+++ b/plugins/module_utils/elastic_common.py
@@ -3,7 +3,7 @@ __metaclass__ = type
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib  # pylint: disable=unused-import
 
 import traceback
-
+import urllib.parse
 
 elastic_found = False
 E_IMP_ERR = None
@@ -50,6 +50,21 @@ class ElasticHelpers():
     def __init__(self, module):
         self.module = module
 
+    def build_connection_url(self, host):
+        '''
+        Given a host, build a connection url using default
+        fragments if the host isnot already a valid url.
+        '''
+        host_url = urllib.parse.urlparse(host)
+        if host_url.scheme and host_url.netloc:
+            return host
+
+        return "{0}://{1}:{2}/".format(
+            self.module.params['auth_scheme'],
+            host,
+            self.module.params['login_port']
+        )
+
     def build_auth(self, module):
         '''
         Build the auth list for elastic according to the passed in parameters
@@ -80,10 +95,7 @@ class ElasticHelpers():
 
     def connect(self):
         auth = self.build_auth(self.module)
-        hosts = list(map(lambda host: "{0}://{1}:{2}/".format(self.module.params['auth_scheme'],
-                                                              host,
-                                                              self.module.params['login_port']),
-                         self.module.params['login_hosts']))
+        hosts = [self.build_connection_url(host) for host in self.module.params['login_hosts']]
         elastic = Elasticsearch(hosts,
                                 timeout=self.module.params['timeout'],
                                 *self.module.params['connection_options'],

--- a/tests/integration/targets/elastic_index_info/tasks/3-test-host-url-with-auth.yml
+++ b/tests/integration/targets/elastic_index_info/tasks/3-test-host-url-with-auth.yml
@@ -6,6 +6,7 @@
       auth_method: http_auth
       login_hosts:
         - http://localhost:9200/
+        - localhost
       timeout: 30
 
   block:

--- a/tests/integration/targets/elastic_index_info/tasks/3-test-host-url-with-auth.yml
+++ b/tests/integration/targets/elastic_index_info/tasks/3-test-host-url-with-auth.yml
@@ -1,0 +1,40 @@
+---
+- vars:
+    elastic_index_parameters: &elastic_index_parameters
+      login_user: elastic
+      login_password: secret
+      auth_method: http_auth
+      login_hosts:
+        - http://localhost:9200/
+      timeout: 30
+
+  block:
+    - name: Delete an index called myindex
+      community.elastic.elastic_index:
+        name: myindex
+        state: absent
+        <<: *elastic_index_parameters
+
+    - name: Create an index called myindex
+      community.elastic.elastic_index:
+        name: myindex
+        <<: *elastic_index_parameters
+      register: result
+
+    - assert:
+        that:
+          - result.msg == "The index 'myindex' was created."
+          - result.changed == True
+
+    - name: Get info for myindex
+      community.elastic.elastic_index_info:
+        name: myindex
+        <<: *elastic_index_parameters
+      register: result
+
+    - assert:
+        that:
+          - result.msg == "Info about index myindex."
+          - result.changed == False
+          - result.myindex is defined
+          - result.myindex.settings is defined


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When the login host module option is already a valid URL, then don't construct one using the module parameters.

This allows for the specification of the connection URL manually for the hosts in the case they are different or require a connection string not supported currently (eg. path).

If it is not a valid URL, then one will be constructed as before, allowing this change to work without impacting existing usage.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
#108
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
elastic_common.py

