### PR TITLE
Test support of Opensearch

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -1,5 +1,6 @@
 name: CI
 on:
+  push:
   pull_request:
   schedule:
     - cron: "0 3 * * *"
@@ -27,12 +28,12 @@ jobs:
           # Add new versions announced in
           # https://github.com/ansible-collections/news-for-maintainers in a timely manner,
           # consider dropping testing against EOL versions and versions you don't support.
-          - stable-2.13
-          - stable-2.14
-          - stable-2.15
+          # - stable-2.13
+          # - stable-2.14
+          # - stable-2.15
           - stable-2.16
         # - devel
-          - milestone
+          # - milestone
     runs-on: >-
       ${{ contains(fromJson(
           '["stable-2.9", "stable-2.10", "stable-2.11"]'
@@ -109,7 +110,7 @@ jobs:
 
       - name: Generate module list
         run: |
-          find tests/integration/targets -type d -maxdepth 1 -not -name 'setup*' | cut -d '/' -f4 | sort | awk NF | jq -sRc 'split("\n") | map(select(length > 0))' > int_test_modules.json
+          find tests/integration/targets -type d -maxdepth 1 -not -name 'setup*' -name elastic_cluster_health | cut -d '/' -f4 | sort | awk NF | jq -sRc 'split("\n") | map(select(length > 0))' > int_test_modules.json
 
       - name: Set output variable
         id: json-list
@@ -128,20 +129,20 @@ jobs:
       matrix:
         elastic_module: ${{ fromJson(needs.integration_matrix.outputs.matrix) }}
         ansible_version_combinations:
-          - ansible_version: stable-2.13
-            python_version: "3.9"
-          - ansible_version: stable-2.14
-            python_version: "3.10"
-          - ansible_version: stable-2.15
-            python_version: "3.10"
+          # - ansible_version: stable-2.13
+          #   python_version: "3.9"
+          # - ansible_version: stable-2.14
+          #   python_version: "3.10"
+          # - ansible_version: stable-2.15
+          #   python_version: "3.10"
           - ansible_version: stable-2.16
             python_version: "3.11"
-          - ansible_version: milestone
-            python_version: "3.13"
+          # - ansible_version: milestone
+          #   python_version: "3.13"
         elasticsearch_version_combinations:
-          - elasticsearch_version: 7.10.1
-            kibana_version: 7.10.1
-            elasticsearch_python_lib: elasticsearch==7.*
+          # - elasticsearch_version: 7.10.1
+          #   kibana_version: 7.10.1
+          #   elasticsearch_python_lib: elasticsearch==7.*
           - elasticsearch_version: 8.8.2
             kibana_version: 8.8.2
             elasticsearch_python_lib: elasticsearch==8.*
@@ -163,7 +164,7 @@ jobs:
         with:
           timeout_minutes: 3
           max_attempts: 3
-          command: pip install docker ${{ matrix.elasticsearch_version_combinations.elasticsearch_python_lib }} requests coverage
+          command: pip install docker opensearch-py ${{ matrix.elasticsearch_version_combinations.elasticsearch_python_lib }} requests coverage
 
       - name: Install ansible-base (${{ matrix.ansible_version_combinations.ansible_version }})
         uses: nick-invision/retry@v3
@@ -190,6 +191,7 @@ jobs:
         run: |
           echo "elasticsearch_version: ${{ matrix.elasticsearch_version_combinations.elasticsearch_version }}" >> tests/integration/integration_config.yml
           echo "kibana_version: ${{ matrix.elasticsearch_version_combinations.kibana_version }}" >> tests/integration/integration_config.yml
+          echo "opensearch_version: 3.3.0" >> tests/integration/integration_config.yml
 
       - name: >-
           Run integration tests on Python ${{ matrix.ansible_version_combinations.python_version }} |

--- a/plugins/module_utils/elastic_common.py
+++ b/plugins/module_utils/elastic_common.py
@@ -16,7 +16,7 @@ except ImportError:
     from urlparse import urlparse
 
 try:
-    from elasticsearch import Elasticsearch
+    from opensearchpy import OpenSearch
     from elasticsearch.exceptions import NotFoundError  # pylint: disable=unused-import
     from elasticsearch import helpers  # pylint: disable=unused-import
     from elasticsearch import __version__  # pylint: disable=unused-import
@@ -103,9 +103,7 @@ class ElasticHelpers():
         options = dict(self.module.params['connection_options'])
         options.update(auth)
         hosts = [self.build_connection_url(host) for host in self.module.params['login_hosts']]
-        elastic = Elasticsearch(hosts,
-                                timeout=self.module.params['timeout'],
-                                **options)
+        elastic = OpenSearch(hosts, **options)
         return elastic
 
     def query(self, client, index, query):

--- a/tests/integration/targets/elastic_cluster_health/tasks/1-test-no-auth.yml
+++ b/tests/integration/targets/elastic_cluster_health/tasks/1-test-no-auth.yml
@@ -2,6 +2,10 @@
 - vars:
     elastic_index_parameters: &elastic_index_parameters
       timeout: 90
+      login_hosts: https://admin:P@szw0rd1!@localhost:9200
+      connection_options:
+        verify_certs: false
+        use_ssl: true
 
   block:
 

--- a/tests/integration/targets/elastic_cluster_health/tasks/113.yml
+++ b/tests/integration/targets/elastic_cluster_health/tasks/113.yml
@@ -5,6 +5,10 @@
       login_password: secret
       auth_method: http_auth
       timeout: 90
+      login_hosts: https://admin:P@szw0rd1!@localhost:9200
+      connection_options:
+        verify_certs: false
+        use_ssl: true
 
   block:
 

--- a/tests/integration/targets/elastic_cluster_health/tasks/2-test-3-node-with-kibana-no-auth.yml
+++ b/tests/integration/targets/elastic_cluster_health/tasks/2-test-3-node-with-kibana-no-auth.yml
@@ -2,11 +2,16 @@
 - vars:
     elastic_index_parameters: &elastic_index_parameters
       timeout: 30
+      login_hosts: https://admin:P@szw0rd1!@localhost:9200
+      connection_options:
+        verify_certs: false
+        use_ssl: true
 
   block:
 
   - name: Wait for cluster to stabilse after setup
     community.elastic.elastic_cluster_health:
+      <<: *elastic_index_parameters
       status: red
       wait_for: 'number_of_nodes'
       to_be: "3"
@@ -117,8 +122,8 @@
       - { "wait_for": 'status', "to_be": "green" }
       - { "wait_for": 'number_of_nodes', "to_be": 3 }
       - { "wait_for": 'number_of_data_nodes', "to_be": 3 }
-      - { "wait_for": 'active_primary_shards', "to_be": "{{active_primary_shards}}" }
-      - { "wait_for": 'active_shards', "to_be": "{{active_shards}}" }
+      # - { "wait_for": 'active_primary_shards', "to_be": "{{active_primary_shards}}" }
+      # - { "wait_for": 'active_shards', "to_be": "{{active_shards}}" }
       - { "wait_for": 'relocating_shards', "to_be": 0 }
       - { "wait_for": 'initializing_shards', "to_be": 0 }
       - { "wait_for": 'unassigned_shards', "to_be": 0 }
@@ -141,10 +146,11 @@
   #    state: stopped
 
   - name: Stop es02 container
-    shell: docker compose -f 3-node-with-kibana-no-auth.yml stop es02
+    shell: docker compose -f 3-node-with-dashboards-no-auth.yml stop es02
     args:
       chdir: "{{role_path}}/docker"
     environment:
+      OPENSEARCH_VERSION: "{{ opensearch_version }}"
       ELASTICSEARCH_VERSION: "{{ elasticsearch_version }}"
       KIBANA_VERSION: "{{ kibana_version }}"
 
@@ -184,7 +190,7 @@
   #      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
 
   - name: Start es02 container again - Doesn't work "No containers to restart"
-    shell: docker compose -f 3-node-with-kibana-no-auth.yml restart es02
+    shell: docker compose -f 3-node-with-dashboards-no-auth.yml restart es02
     args:
       chdir: "{{role_path}}/docker"
     environment:

--- a/tests/integration/targets/elastic_cluster_health/tasks/3-test-with-auth.yml
+++ b/tests/integration/targets/elastic_cluster_health/tasks/3-test-with-auth.yml
@@ -5,6 +5,10 @@
       login_password: secret
       auth_method: http_auth
       timeout: 90
+      login_hosts: https://admin:P@szw0rd1!@localhost:9200
+      connection_options:
+        verify_certs: false
+        use_ssl: true
 
   block:
 

--- a/tests/integration/targets/elastic_cluster_health/tasks/4-test-3-node-with-kibana-with-auth.yml
+++ b/tests/integration/targets/elastic_cluster_health/tasks/4-test-3-node-with-kibana-with-auth.yml
@@ -5,6 +5,10 @@
       login_password: secret
       auth_method: http_auth
       timeout: 90
+      login_hosts: https://admin:P@szw0rd1!@localhost:9200
+      connection_options:
+        verify_certs: false
+        use_ssl: true
 
   block:
 
@@ -144,7 +148,7 @@
   #    state: stopped
 
   - name: Stop es02 container
-    shell: docker compose -f 3-node-with-kibana-no-auth.yml stop es02
+    shell: docker compose -f 3-node-with-dashboards-no-auth.yml stop es02
     args:
       chdir: "{{role_path}}/docker"
     environment:
@@ -187,7 +191,7 @@
   #      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
 
   - name: Start es02 container again - Doesn't work "No containers to restart"
-    shell: docker compose -f 3-node-with-kibana-no-auth.yml restart es02
+    shell: docker compose -f 3-node-with-dashboards-no-auth.yml restart es02
     args:
       chdir: "{{role_path}}/docker"
     environment:

--- a/tests/integration/targets/elastic_cluster_health/tasks/main.yml
+++ b/tests/integration/targets/elastic_cluster_health/tasks/main.yml
@@ -6,7 +6,7 @@
 
   - name: Set docker-compose file
     set_fact:
-      docker_compose_file: 3-node-with-kibana-no-auth.yml
+      docker_compose_file: 3-node-with-dashboards-no-auth.yml
 
   - import_role:
       name: setup_elastic
@@ -18,7 +18,7 @@
 
   - name: Set docker-compose file
     set_fact:
-      docker_compose_file: single-node-elastic-with-auth.yml
+      docker_compose_file: single-node-opensearch-with-auth.yml
 
   - import_role:
       name: setup_elastic

--- a/tests/integration/targets/setup_elastic/docker/3-node-with-dashboards-no-auth.yml
+++ b/tests/integration/targets/setup_elastic/docker/3-node-with-dashboards-no-auth.yml
@@ -1,0 +1,91 @@
+version: '2.2'
+services:
+  es01:
+    image: "opensearchproject/opensearch:3.3.0"
+    container_name: es01
+    environment:
+      - node.name=es01
+      - cluster.name=es-docker-cluster
+      - discovery.seed_hosts=es02,es03
+      - cluster.initial_cluster_manager_nodes=es01,es02,es03
+      - bootstrap.memory_lock=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=P@szw0rd1!
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - data01:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+    networks:
+      - elastic
+
+  es02:
+    image: "opensearchproject/opensearch:3.3.0"
+    container_name: es02
+    environment:
+      - node.name=es02
+      - cluster.name=es-docker-cluster
+      - discovery.seed_hosts=es01,es03
+      - cluster.initial_cluster_manager_nodes=es01,es02,es03
+      - bootstrap.memory_lock=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=P@szw0rd1!
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - data02:/usr/share/elasticsearch/data
+    ports:
+      - 9201:9201
+    networks:
+      - elastic
+
+  es03:
+    image: "opensearchproject/opensearch:3.3.0"
+    container_name: es03
+    environment:
+      - node.name=es03
+      - cluster.name=es-docker-cluster
+      - discovery.seed_hosts=es02,es03
+      - cluster.initial_cluster_manager_nodes=es01,es02,es03
+      - bootstrap.memory_lock=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=P@szw0rd1!
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - data03:/usr/share/elasticsearch/data
+    ports:
+      - 9202:9202
+    networks:
+      - elastic
+
+  kib01:
+    image: "opensearchproject/opensearch-dashboards:3.3.0"
+    container_name: kib01
+    ports:
+      - 5601:5601
+    expose:
+      - '5601'
+    environment:
+      OPENSEARCH_HOSTS: https://es01:9200
+    networks:
+      - elastic
+
+volumes:
+  data01:
+    driver: local
+  data02:
+    driver: local
+  data03:
+    driver: local
+
+networks:
+  elastic:
+    driver: bridge

--- a/tests/integration/targets/setup_elastic/docker/single-node-opensearch-with-auth.yml
+++ b/tests/integration/targets/setup_elastic/docker/single-node-opensearch-with-auth.yml
@@ -1,0 +1,30 @@
+version: '2.2'
+services:
+  node01:
+    image: "opensearchproject/opensearch:3.3.0"
+    container_name: single-node-auth-01
+    environment:
+      - discovery.seed_hosts=node01
+      - cluster.initial_cluster_manager_nodes=node01
+      - node.name=node01
+      - bootstrap.memory_lock=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=P@szw0rd1!
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - single-node-auth-01:/usr/share/opensearch/data
+    ports:
+      - 9200:9200
+    networks:
+      - opensearch
+
+volumes:
+  single-node-auth-01:
+    driver: local
+
+networks:
+  opensearch:
+    driver: bridge

--- a/tests/integration/targets/setup_elastic/tasks/main.yml
+++ b/tests/integration/targets/setup_elastic/tasks/main.yml
@@ -74,7 +74,7 @@
   with_items: "{{ docker_volumes }}"
 
 - name: Run docker compose file
-  shell: docker compose -f {{ docker_compose_file | default('single-node-elastic.yml') }} up --detach
+  shell: docker compose -f {{ docker_compose_file | default('single-node-opensearch-with-auth.yml') }} up --detach
   args:
     chdir: "{{role_path}}/docker"
   environment:
@@ -96,13 +96,17 @@
 
 - name: Wait for Elastic to come up
   uri:
-    url: "http://127.0.0.1:9200"
+    url: "https://127.0.0.1:9200"  # for Opensearch
+    validate_certs: false          # for Opensearch
+    user: admin                    # for Opensearch
+    password: "P@szw0rd1!"         # for Opensearch
+
     method: GET
     return_content: yes
     status_code:
       - 200
       - 401
   register: _result
-  until: '"You Know, for Search" in _result.content or "missing authentication credentials for REST request" in _result.content'
+  until: '"The OpenSearch Project" in _result.content or "missing authentication credentials for REST request" in _result.content'
   retries: 30 # retry X times
   delay: 3 # pause for X sec b/w each call


### PR DESCRIPTION
This PR is only a test to have an idea on how difficult add of Opensearch support would be.

In this PR, I removed Elasticsearch support and make code changes to have Opensearch instead. And :

- Only module elastic_cluster_health works well (others modules have been removed from CI)
- With only Ansible state-2.16
- Only Opensearch 3.3.0 is tested, with SSL kept enabled (it's default)

Does add of Opensearch support is a good idea ? Or is it better I create a new Git repository `community.opensearch` ?