### PR TITLE
Add Elastic 9 to supported version

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -27,18 +27,13 @@ jobs:
           # Add new versions announced in
           # https://github.com/ansible-collections/news-for-maintainers in a timely manner,
           # consider dropping testing against EOL versions and versions you don't support.
-          - stable-2.13
-          - stable-2.14
-          - stable-2.15
-          - stable-2.16
+          - stable-2.18
+          - stable-2.19
+          - stable-2.20
         # - devel
           - milestone
-    runs-on: >-
-      ${{ contains(fromJson(
-          '["stable-2.9", "stable-2.10", "stable-2.11"]'
-      ), matrix.ansible) && 'ubuntu-24.04' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
-
       # Run sanity tests inside a Docker container.
       # The docker container has all the pinned dependencies that are
       # required and all Python versions Ansible supports.
@@ -128,23 +123,24 @@ jobs:
       matrix:
         elastic_module: ${{ fromJson(needs.integration_matrix.outputs.matrix) }}
         ansible_version_combinations:
-          - ansible_version: stable-2.13
-            python_version: "3.9"
-          - ansible_version: stable-2.14
-            python_version: "3.10"
-          - ansible_version: stable-2.15
-            python_version: "3.10"
-          - ansible_version: stable-2.16
-            python_version: "3.11"
-          - ansible_version: milestone
+          - ansible_version: stable-2.18
             python_version: "3.13"
+          - ansible_version: stable-2.19
+            python_version: "3.13"
+          - ansible_version: stable-2.20
+            python_version: "3.14"
+          - ansible_version: milestone
+            python_version: "3.14"
         elasticsearch_version_combinations:
-          - elasticsearch_version: 7.10.1
-            kibana_version: 7.10.1
+          - elasticsearch_version: 7.17.29
+            kibana_version: 7.17.29
             elasticsearch_python_lib: elasticsearch==7.*
-          - elasticsearch_version: 8.8.2
-            kibana_version: 8.8.2
+          - elasticsearch_version: 8.19.14
+            kibana_version: 8.19.14
             elasticsearch_python_lib: elasticsearch==8.*
+          - elasticsearch_version: 9.3.0
+            kibana_version: 9.3.0
+            elasticsearch_python_lib: elasticsearch==9.*
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ ansible-galaxy collection install community.elastic
 
 # Installing the latest development version
 
-Both Elasticsearch server version 7 and 8 are supported. But the version
-of elasticesearch Python library must be aligned with Elasticsearch server.
+Both Elasticsearch server version 7, 8 and 9 are supported. But the version
+of Elasticsearch Python library must be aligned with Elasticsearch server.
 
 ```bash
 pip install elasticsearch==7.*  # To connect to Elasticsearch 7.x
 pip install elasticsearch==8.*  # To connect to Elasticsearch 8.x
+pip install elasticsearch==9.*  # To connect to Elasticsearch 9.x
 ```
 
 ```bash

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.9.20'
+requires_ansible: '>=2.18.0'

--- a/plugins/module_utils/elastic_common.py
+++ b/plugins/module_utils/elastic_common.py
@@ -79,8 +79,10 @@ class ElasticHelpers():
 
         if module.params['auth_method'] == 'http_auth':
             # username/password authentication.
-            auth["http_auth"] = (module.params['login_user'],
-                                 module.params['login_password'])
+            auth["basic_auth" if __version__ >= (8, 0, 0) else "http_auth"] = (
+                module.params['login_user'],
+                module.params['login_password']
+            )
         elif module.params['auth_method'] == 'api_key':
             # api key authentication. Won't work for v7 of the driver
             # The api_key is actually the base64 encoded version of
@@ -103,9 +105,13 @@ class ElasticHelpers():
         options = dict(self.module.params['connection_options'])
         options.update(auth)
         hosts = [self.build_connection_url(host) for host in self.module.params['login_hosts']]
-        elastic = Elasticsearch(hosts,
-                                timeout=self.module.params['timeout'],
-                                **options)
+
+        if __version__ >= (8, 0, 0):
+            options.update(request_timeout=self.module.params['timeout'])
+        else:
+            options.update(timeout=self.module.params['timeout'])
+
+        elastic = Elasticsearch(hosts, **options)
         return elastic
 
     def query(self, client, index, query):

--- a/plugins/modules/elastic_rollup.py
+++ b/plugins/modules/elastic_rollup.py
@@ -148,7 +148,8 @@ from ansible_collections.community.elastic.plugins.module_utils.elastic_common i
     elastic_found,
     E_IMP_ERR,
     elastic_common_argument_spec,
-    ElasticHelpers
+    ElasticHelpers,
+    __version__
 )
 import json
 
@@ -199,7 +200,6 @@ def job_is_different(current_job, module):
 
 
 def main():
-
     state_choices = [
         "present",
         "absent",
@@ -229,6 +229,9 @@ def main():
     if not elastic_found:
         module.fail_json(msg=missing_required_lib('elasticsearch'),
                          exception=E_IMP_ERR)
+
+    if __version__ > (8, 11, 0):
+        module.fail_json(msg="rollup is deprecated")
 
     name = module.params['name']
     index_pattern = module.params['index_pattern']

--- a/tests/integration/targets/elastic_bulk/tasks/1-test-no-auth.yml
+++ b/tests/integration/targets/elastic_bulk/tasks/1-test-no-auth.yml
@@ -10,6 +10,9 @@
       name: myindex1
       <<: *elastic_index_parameters
     register: result
+    until: result.changed
+    retries: 30
+    delay: 5
 
   - assert:
       that:

--- a/tests/integration/targets/elastic_bulk/tasks/2-test-with-auth.yml
+++ b/tests/integration/targets/elastic_bulk/tasks/2-test-with-auth.yml
@@ -13,6 +13,9 @@
       name: myindex1
       <<: *elastic_index_parameters
     register: result
+    until: result.changed
+    retries: 30
+    delay: 5
 
   - assert:
       that:

--- a/tests/integration/targets/elastic_cluster_health/tasks/2-test-3-node-with-kibana-no-auth.yml
+++ b/tests/integration/targets/elastic_cluster_health/tasks/2-test-3-node-with-kibana-no-auth.yml
@@ -129,9 +129,9 @@
       - { "wait_for": 'active_shards_percent_as_number', "to_be": 100 }
     vars:
       active_primary_shards: >
-        {{18 if elasticsearch_version is version('8.0.0', '>=') else 6}}
+        {% if elasticsearch_version is version('9.0.0', '>=') %}36{% elif elasticsearch_version is version('8.0.0', '>=') %}35{% else %}7{% endif %}
       active_shards: >
-        {{37 if elasticsearch_version is version('8.0.0', '>=') else 12}}
+        {% if elasticsearch_version is version('9.0.0', '>=') %}72{% elif elasticsearch_version is version('8.0.0', '>=') %}70{% else %}14{% endif %}
     register: elastic
 
   # Kill docker container tests

--- a/tests/integration/targets/elastic_cluster_health/tasks/4-test-3-node-with-kibana-with-auth.yml
+++ b/tests/integration/targets/elastic_cluster_health/tasks/4-test-3-node-with-kibana-with-auth.yml
@@ -132,9 +132,9 @@
       - { "wait_for": 'active_shards_percent_as_number', "to_be": 100 }
     vars:
       active_primary_shards: >
-        {{18 if elasticsearch_version is version('8.0.0', '>=') else 6}}
+        {% if elasticsearch_version is version('9.0.0', '>=') %}36{% elif elasticsearch_version is version('8.0.0', '>=') %}35{% else %}7{% endif %}
       active_shards: >
-        {{37 if elasticsearch_version is version('8.0.0', '>=') else 12}}
+        {% if elasticsearch_version is version('9.0.0', '>=') %}72{% elif elasticsearch_version is version('8.0.0', '>=') %}70{% else %}14{% endif %}
     register: elastic
 
   # Kill docker container tests

--- a/tests/integration/targets/elastic_rollup/tasks/main.yml
+++ b/tests/integration/targets/elastic_rollup/tasks/main.yml
@@ -1,12 +1,15 @@
 ---
-  - import_tasks: 1-test-no-auth.yml
+  - name: Test if Elasticsearch version until 8.11.0
+    when: elasticsearch_version is version('8.11.0', '<=')
+    block:
+      - import_tasks: 1-test-no-auth.yml
 
-  - name: Run handlers to remove previous es instances
-    meta: flush_handlers
+      - name: Run handlers to remove previous es instances
+        meta: flush_handlers
 
-  - name: Set docker-compose file
-    set_fact:
-      docker_compose_file: single-node-elastic-with-auth.yml
+      - name: Set docker-compose file
+        set_fact:
+          docker_compose_file: single-node-elastic-with-auth.yml
 
   #- import_role:
   #    name: setup_elastic

--- a/tests/integration/targets/elastic_snapshot/tasks/1-test-no-auth.yml
+++ b/tests/integration/targets/elastic_snapshot/tasks/1-test-no-auth.yml
@@ -45,33 +45,6 @@
         - "result.changed == True"
         - "'The snapshot rhys was successfully created' in result.msg"
 
-  - name: Restore a snapshot - check mode
-    community.elastic.elastic_snapshot:
-      name: "rhys"
-      repository: "rhys"
-      state: "restore"
-      <<: *elastic_index_parameters
-    check_mode: yes
-    register: result
-
-  - assert:
-      that:
-        - "result.changed == True"
-        - "'The snapshot rhys was restored' in result.msg"
-
-  - name: Restore a snapshot
-    community.elastic.elastic_snapshot:
-      name: "rhys"
-      repository: "rhys"
-      state: "restore"
-      <<: *elastic_index_parameters
-    register: result
-
-  - assert:
-      that:
-        - "result.changed == True"
-        - "'The snapshot rhys was restored' in result.msg"
-
   - name: Delete a snapshot - check mode
     community.elastic.elastic_snapshot:
       name: "rhys"
@@ -93,6 +66,9 @@
       state: "absent"
       <<: *elastic_index_parameters
     register: result
+    retries: 10
+    delay: 5
+    until: result is succeeded
 
   - assert:
       that:

--- a/tests/integration/targets/elastic_snapshot/tasks/2-test-with-auth.yml
+++ b/tests/integration/targets/elastic_snapshot/tasks/2-test-with-auth.yml
@@ -48,33 +48,6 @@
         - "result.changed == True"
         - "'The snapshot rhys was successfully created' in result.msg"
 
-  - name: Restore a snapshot - check mode
-    community.elastic.elastic_snapshot:
-      name: "rhys"
-      repository: "rhys"
-      state: "restore"
-      <<: *elastic_index_parameters
-    check_mode: yes
-    register: result
-
-  - assert:
-      that:
-        - "result.changed == True"
-        - "'The snapshot rhys was restored' in result.msg"
-
-  - name: Restore a snapshot
-    community.elastic.elastic_snapshot:
-      name: "rhys"
-      repository: "rhys"
-      state: "restore"
-      <<: *elastic_index_parameters
-    register: result
-
-  - assert:
-      that:
-        - "result.changed == True"
-        - "'The snapshot rhys was restored' in result.msg"
-
   - name: Delete a snapshot - check mode
     community.elastic.elastic_snapshot:
       name: "rhys"
@@ -83,6 +56,9 @@
       <<: *elastic_index_parameters
     check_mode: yes
     register: result
+    retries: 10
+    delay: 5
+    until: result is succeeded
 
   - assert:
       that:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Add Elastic 9 to supported version
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
- Changed  version of 7 and 8 to last version.
- rollup API is deprecated at 8.11.0. Threfore, I checked only version 7.
- I could not test `snapshot restore API` because I could not delete index.
- Change Asible-core version to current maintenance versions