### PR TITLE
Replace deprecated imports

### DIFF
--- a/plugins/modules/elastic_api_key.py
+++ b/plugins/modules/elastic_api_key.py
@@ -126,10 +126,10 @@ RETURN = r'''
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 try:
     import elasticsearch
 except ImportError:

--- a/plugins/modules/elastic_bulk.py
+++ b/plugins/modules/elastic_bulk.py
@@ -90,7 +90,7 @@ RETURN = r'''
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 from ansible_collections.community.elastic.plugins.module_utils.elastic_common import (

--- a/plugins/modules/elastic_cluster_health.py
+++ b/plugins/modules/elastic_cluster_health.py
@@ -110,7 +110,7 @@ RETURN = r'''
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 from ansible_collections.community.elastic.plugins.module_utils.elastic_common import (

--- a/plugins/modules/elastic_cluster_settings.py
+++ b/plugins/modules/elastic_cluster_settings.py
@@ -57,7 +57,7 @@ RETURN = r'''
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 from ansible_collections.community.elastic.plugins.module_utils.elastic_common import (

--- a/plugins/modules/elastic_index.py
+++ b/plugins/modules/elastic_index.py
@@ -99,7 +99,7 @@ RETURN = r'''
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 from ansible_collections.community.elastic.plugins.module_utils.elastic_common import (

--- a/plugins/modules/elastic_index_info.py
+++ b/plugins/modules/elastic_index_info.py
@@ -47,7 +47,7 @@ RETURN = r'''
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 from ansible_collections.community.elastic.plugins.module_utils.elastic_common import (

--- a/plugins/modules/elastic_index_lifecycle.py
+++ b/plugins/modules/elastic_index_lifecycle.py
@@ -76,7 +76,7 @@ RETURN = r'''
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 from ansible_collections.community.elastic.plugins.module_utils.elastic_common import (

--- a/plugins/modules/elastic_logstash_pipeline.py
+++ b/plugins/modules/elastic_logstash_pipeline.py
@@ -151,7 +151,7 @@ msg:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.elastic.plugins.module_utils.elastic_common import (
     missing_required_lib,

--- a/plugins/modules/elastic_pipeline.py
+++ b/plugins/modules/elastic_pipeline.py
@@ -77,7 +77,7 @@ RETURN = r'''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 from ansible_collections.community.elastic.plugins.module_utils.elastic_common import (

--- a/plugins/modules/elastic_reindex.py
+++ b/plugins/modules/elastic_reindex.py
@@ -89,7 +89,7 @@ took:
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 from ansible_collections.community.elastic.plugins.module_utils.elastic_common import (

--- a/plugins/modules/elastic_role.py
+++ b/plugins/modules/elastic_role.py
@@ -103,7 +103,7 @@ RETURN = r'''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import json
 
 

--- a/plugins/modules/elastic_rollup.py
+++ b/plugins/modules/elastic_rollup.py
@@ -140,7 +140,7 @@ RETURN = r'''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 from ansible_collections.community.elastic.plugins.module_utils.elastic_common import (

--- a/plugins/modules/elastic_snapshot.py
+++ b/plugins/modules/elastic_snapshot.py
@@ -102,7 +102,7 @@ EXAMPLES = r'''
 RETURN = r'''
 '''
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 from ansible_collections.community.elastic.plugins.module_utils.elastic_common import (

--- a/plugins/modules/elastic_snapshot_repository.py
+++ b/plugins/modules/elastic_snapshot_repository.py
@@ -73,7 +73,7 @@ EXAMPLES = r'''
 RETURN = r'''
 '''
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 from ansible_collections.community.elastic.plugins.module_utils.elastic_common import (

--- a/plugins/modules/elastic_transform.py
+++ b/plugins/modules/elastic_transform.py
@@ -224,7 +224,7 @@ RETURN = r'''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 from ansible_collections.community.elastic.plugins.module_utils.elastic_common import (

--- a/plugins/modules/elastic_user.py
+++ b/plugins/modules/elastic_user.py
@@ -98,7 +98,7 @@ EXAMPLES = r'''
 RETURN = r'''
 '''
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import json
 
 


### PR DESCRIPTION
##### SUMMARY
Replace deprecated ansible.module_utils._text imports with ansible.module_utils.common.text.converters.

##### ISSUE TYPE
- Bugfix Pull Request